### PR TITLE
add RunningInstances table config

### DIFF
--- a/cdk/lib/constructs/dynamodb-tables.ts
+++ b/cdk/lib/constructs/dynamodb-tables.ts
@@ -1,21 +1,37 @@
 import { Construct } from "constructs";
-import { Table, AttributeType, BillingMode } from "aws-cdk-lib/aws-dynamodb";
+import { Table, AttributeType, BillingMode, ProjectionType } from "aws-cdk-lib/aws-dynamodb";
 import { RemovalPolicy } from "aws-cdk-lib";
 
 export class DynamoDbTables extends Construct {
-  // Add your DynamoDB tables here as you need them
-  // Example:
-  // public readonly usersTable: Table;
-  // public readonly ordersTable: Table;
+    public runningInstancesTable: Table;
 
-  constructor(scope: Construct, id: string) {
-    super(scope, id);
+    constructor(scope: Construct, id: string) {
+        super(scope, id);
 
-    // Example table - uncomment and modify as needed
-    // this.usersTable = new Table(this, "UsersTable", {
-    //   partitionKey: { name: "userId", type: AttributeType.STRING },
-    //   billingMode: BillingMode.PAY_PER_REQUEST,
-    //   removalPolicy: RemovalPolicy.DESTROY, // Use RETAIN for production
-    // });
-  }
+        this.setupRunningInstances()
+    }
+
+    /**
+    * Schema: instanceId (PK), instanceArn, ebsVolumes (list), creationTime, 
+    *         status, region, instanceType, lastModifiedTime
+    */
+    setupRunningInstances(): void {
+        this.runningInstancesTable = new Table(this, "RunningInstances", {
+            partitionKey: { name: "instanceId", type: AttributeType.STRING },
+            pointInTimeRecovery: true,
+            billingMode: BillingMode.PAY_PER_REQUEST,
+            // TODO: add environment based removal policy config
+            removalPolicy: RemovalPolicy.DESTROY, // Use RETAIN for production
+        });
+
+        // TODO future: add autoscaling group
+        // TODO: or add grantX to specific lambda functions
+
+        this.runningInstancesTable.addGlobalSecondaryIndex({
+            indexName: "StatusCreationTimeIndex",
+            partitionKey: { name: "status", type: AttributeType.STRING },
+            sortKey: { name: "creationTime", type: AttributeType.STRING },
+            projectionType: ProjectionType.ALL,
+        });
+    }
 }


### PR DESCRIPTION
## Summary
Added reusable setup function for the RunningInstances table in the dynanodb table constructor with some basic config and schema proposal for table at https://dbdiagram.io/d/RunningInstances-Schema-68e192d3d2b621e42248bec8

## Notes
- Was a little unsure where we wanted to go with things so I added a few TODO comments for things like autoscaling, specific lambda grant access, and environment var based policy removal.

## Changes

- Implemented {Running Instances} constructor
- Added table index on the status column
- Created Running Instances schema proposal

## How to test

### Examples:
- `npm install`
- `npm run cdk`
