### PR TITLE
fix: updated dependencies, moved SAM template to cdk dir

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -15,6 +15,7 @@
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
+        "@types/aws-lambda": "^8.10.156",
         "@types/jest": "^29.5.14",
         "@types/node": "22.7.9",
         "aws-cdk": "2.1029.3",
@@ -1016,6 +1017,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.156",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.156.tgz",
+      "integrity": "sha512-LElQP+QliVWykC7OF8dNr04z++HJCMO2lF7k9HuKoSDARqhcjHq8MzbrRwujCSDeBHIlvaimbuY/tVZL36KXFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1728,6 +1736,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -1744,6 +1753,7 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1975,6 +1985,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -3432,6 +3443,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3822,6 +3834,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -11,11 +11,12 @@
     "cdk": "cdk"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.156",
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
+    "aws-cdk": "2.1029.3",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "aws-cdk": "2.1029.3",
     "ts-node": "^10.9.2",
     "typescript": "~5.6.3"
   },

--- a/cdk/template.yml
+++ b/cdk/template.yml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: 'Lunaris API for local testing'
+
+Globals:
+  Function:
+    Timeout: 30
+    Runtime: nodejs22.x
+
+Resources:
+  # Deploy Instance Function
+  DeployInstanceFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: cdk/lambda/
+      Handler: deployInstance.handler
+      Events:
+        DeployInstanceApi:
+          Type: Api
+          Properties:
+            Path: /deployInstance
+            Method: post
+
+Outputs:
+  DeployInstanceApi:
+    Description: "API Gateway endpoint URL for Deploy Instance function"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/deployInstance"

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -1,17 +1,17 @@
-// import * as cdk from 'aws-cdk-lib';
-// import { Template } from 'aws-cdk-lib/assertions';
-// import * as Cdk from '../lib/cdk-stack';
+// // import * as cdk from 'aws-cdk-lib';
+// // import { Template } from 'aws-cdk-lib/assertions';
+// // import * as Cdk from '../lib/cdk-stack';
 
-// example test. To run these tests, uncomment this file along with the
-// example resource in lib/cdk-stack.ts
-test('SQS Queue Created', () => {
-//   const app = new cdk.App();
-//     // WHEN
-//   const stack = new Cdk.CdkStack(app, 'MyTestStack');
-//     // THEN
-//   const template = Template.fromStack(stack);
+// // example test. To run these tests, uncomment this file along with the
+// // example resource in lib/cdk-stack.ts
+// test('SQS Queue Created', () => {
+// //   const app = new cdk.App();
+// //     // WHEN
+// //   const stack = new Cdk.CdkStack(app, 'MyTestStack');
+// //     // THEN
+// //   const template = Template.fromStack(stack);
 
-//   template.hasResourceProperties('AWS::SQS::Queue', {
-//     VisibilityTimeout: 300
-//   });
-});
+// //   template.hasResourceProperties('AWS::SQS::Queue', {
+// //     VisibilityTimeout: 300
+// //   });
+// });


### PR DESCRIPTION
## Summary
Moved SAM template file into CDK and updated dependencies inside cdk dir

## How to test
- `cd cdk`
- `npm install`
- compile with: `npx tsc cdk/lambda/deployInstance.ts --target es2020 --module commonjs`
- run SAM: `sam local start-api`
- may need to install SAM first: `brew install aws-sam-cli`