### PR TITLE
Add helper method for populating standard api gateway responses

### DIFF
--- a/cdk/lib/constructs/api-gateway.ts
+++ b/cdk/lib/constructs/api-gateway.ts
@@ -1,5 +1,10 @@
 import { Construct } from "constructs";
-import { type IRestApi, LambdaRestApi, LambdaIntegration, MethodResponse } from "aws-cdk-lib/aws-apigateway";
+import {
+    type IRestApi,
+    LambdaRestApi,
+    LambdaIntegration,
+    MethodResponse,
+} from "aws-cdk-lib/aws-apigateway";
 import { Function } from "aws-cdk-lib/aws-lambda";
 
 export interface ApiGatewayProps {
@@ -96,6 +101,6 @@ export class ApiGateway extends Construct {
                     "application/json": { modelId: "Error" },
                 },
             },
-        ]
+        ];
     }
 }


### PR DESCRIPTION
## Summary

- Simplify api gateway endpoint creation with a standard response method population for DRY code

## Changes

- Created private helper with standard status code and responses.
- Used helper in endpoint creation methods

## How to test

- `npm run docker:test:lambda`

