### PR TITLE
hook up frontend to games table api

### DIFF
--- a/frontend/app/browse/page.tsx
+++ b/frontend/app/browse/page.tsx
@@ -1,11 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Gamepad2, Search, Filter, User, LogOut } from "lucide-react";
 import { Dashboard } from "@/components/dashboard";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { GameCard } from "@/components/game-card/game-card";
+import { apiClient, type Game } from "@/lib/api-client";
+import gamesData from "@/lib/data.json";
+
+const fallbackGames: Game[] = gamesData.games.map((g) => ({
+    gameId: g.id,
+    name: g.name,
+    description: g.description || "",
+    imageUrl: g.image,
+    tags: g.tags,
+    modes: g.modes,
+    ebsSnapshotId: "",
+    minInstanceType: "",
+    playable: g.playable,
+}));
 
 export default function BrowsePage() {
+    const [games, setGames] = useState<Game[]>(fallbackGames);
+    const mid = Math.ceil(games.length / 2);
+    const featuredGames = games.slice(0, mid);
+    const popularGames = games.slice(mid);
+
+    useEffect(() => {
+        apiClient
+            .getGames()
+            .then((res) => setGames(res.data))
+            .catch(() => {}); // keep fallback on error
+    }, []);
+
     return (
         <>
             <div className="relative z-0 min-h-screen">
@@ -62,19 +92,15 @@ export default function BrowsePage() {
                         <h2 className="text-2xl font-semibold mb-6">Featured Games</h2>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                             {featuredGames.map((game) => (
-                                <div key={game.id} className="group cursor-pointer">
-                                    <div className="aspect-video bg-muted rounded-lg mb-3 overflow-hidden">
-                                        <div className="w-full h-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white font-bold text-xl">
-                                            {game.name}
-                                        </div>
-                                    </div>
-                                    <h3 className="font-semibold group-hover:text-primary transition-colors">
-                                        {game.name}
-                                    </h3>
-                                    <p className="text-sm text-muted-foreground">
-                                        {game.genre} • {game.playTime}
-                                    </p>
-                                </div>
+                                <GameCard
+                                    key={game.gameId}
+                                    id={game.gameId}
+                                    src={game.imageUrl}
+                                    alt={game.name}
+                                    title={game.name}
+                                    modes={game.modes ?? []}
+                                    tags={game.tags}
+                                />
                             ))}
                         </div>
                     </section>
@@ -84,19 +110,15 @@ export default function BrowsePage() {
                         <h2 className="text-2xl font-semibold mb-6">Popular Games</h2>
                         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
                             {popularGames.map((game) => (
-                                <div key={game.id} className="group cursor-pointer">
-                                    <div className="aspect-video bg-muted rounded-lg mb-3 overflow-hidden">
-                                        <div className="w-full h-full bg-gradient-to-br from-green-500 to-blue-600 flex items-center justify-center text-white font-bold text-xl">
-                                            {game.name}
-                                        </div>
-                                    </div>
-                                    <h3 className="font-semibold group-hover:text-primary transition-colors">
-                                        {game.name}
-                                    </h3>
-                                    <p className="text-sm text-muted-foreground">
-                                        {game.genre} • {game.playTime}
-                                    </p>
-                                </div>
+                                <GameCard
+                                    key={game.gameId}
+                                    id={game.gameId}
+                                    src={game.imageUrl}
+                                    alt={game.name}
+                                    title={game.name}
+                                    modes={game.modes ?? []}
+                                    tags={game.tags}
+                                />
                             ))}
                         </div>
                     </section>
@@ -105,18 +127,3 @@ export default function BrowsePage() {
         </>
     );
 }
-
-// Sample game data
-const featuredGames = [
-    { id: 1, name: "Cyber Adventure", genre: "Action", playTime: "15-30 min" },
-    { id: 2, name: "Space Odyssey", genre: "Sci-Fi", playTime: "30-45 min" },
-    { id: 3, name: "Mystic Quest", genre: "RPG", playTime: "45-60 min" },
-    { id: 4, name: "Racing Thunder", genre: "Racing", playTime: "10-20 min" },
-];
-
-const popularGames = [
-    { id: 5, name: "Battle Royale", genre: "FPS", playTime: "20-40 min" },
-    { id: 6, name: "Puzzle Master", genre: "Puzzle", playTime: "5-15 min" },
-    { id: 7, name: "Fantasy World", genre: "Adventure", playTime: "30-60 min" },
-    { id: 8, name: "Sports Arena", genre: "Sports", playTime: "15-30 min" },
-];

--- a/frontend/app/games/[id]/page.tsx
+++ b/frontend/app/games/[id]/page.tsx
@@ -7,6 +7,7 @@ import { ChevronLeft, Gamepad2, Keyboard } from "lucide-react";
 import gamesData from "@/lib/data.json";
 import {
     apiClient,
+    type Game,
     type GetDeploymentStatusResponse,
     type DeploymentStatus,
 } from "@/lib/api-client";
@@ -25,10 +26,33 @@ interface StreamingCredentials {
     instanceId?: string;
 }
 
+function toGame(g: (typeof gamesData.games)[number]): Game {
+    return {
+        gameId: g.id,
+        name: g.name,
+        description: g.description || "",
+        imageUrl: g.image,
+        tags: g.tags,
+        modes: g.modes,
+        ebsSnapshotId: "",
+        minInstanceType: "",
+        playable: g.playable,
+    };
+}
+
 export default function GamePage({ params }: GamePageProps) {
     const router = useRouter();
     const { id } = use(params);
-    const game = gamesData.games.find((g) => g.id === id);
+
+    const fallback = gamesData.games.find((g) => g.id === id);
+    const [game, setGame] = useState<Game | null>(fallback ? toGame(fallback) : null);
+
+    useEffect(() => {
+        apiClient
+            .getGame(id)
+            .then((res) => setGame(res.data))
+            .catch(() => {}); // keep fallback on error
+    }, [id]);
 
     const [userId] = useState("test123"); // TODO: Get from auth context
     const [isDeploying, setIsDeploying] = useState(false);
@@ -235,7 +259,7 @@ export default function GamePage({ params }: GamePageProps) {
             <div className="flex gap-12 mb-16">
                 {/* Game Cover Image */}
                 <div className="w-[489px] h-[321px] rounded-[10px] overflow-hidden shadow-[8px_7px_20px_0px_rgba(0,0,0,0.12)] shrink-0 relative">
-                    <Image src={game.image} alt={game.name} fill className="object-cover" />
+                    <Image src={game.imageUrl} alt={game.name} fill className="object-cover" />
                 </div>
 
                 {/* Game Info */}
@@ -258,7 +282,7 @@ export default function GamePage({ params }: GamePageProps) {
                                 {tag}
                             </div>
                         ))}
-                        {game.modes.map((mode, idx) => (
+                        {(game.modes ?? []).map((mode, idx) => (
                             <div
                                 key={idx}
                                 className="border border-[#e6daf6] text-[#e6daf6] px-4 py-2 rounded-lg font-space-grotesk text-base shadow-[8px_7px_20px_0px_rgba(0,0,0,0.12)]"

--- a/frontend/components/game-card/game-cards-row.tsx
+++ b/frontend/components/game-card/game-cards-row.tsx
@@ -1,6 +1,20 @@
-import { ReactNode } from "react";
+"use client";
+
+import { ReactNode, useEffect, useState } from "react";
 import { GameCard } from "./game-card";
+import { apiClient, type Game } from "@/lib/api-client";
 import gamesData from "@/lib/data.json";
+
+const fallbackGames: Game[] = gamesData.games.map((g) => ({
+    gameId: g.id,
+    name: g.name,
+    description: "",
+    imageUrl: g.image,
+    tags: g.tags,
+    modes: g.modes,
+    ebsSnapshotId: "",
+    minInstanceType: "",
+}));
 
 interface CarouselProps {
     children: ReactNode;
@@ -19,36 +33,34 @@ const Carousel = ({ children, className = "" }: CarouselProps) => (
     </div>
 );
 
-type GamesDataset = typeof gamesData;
-type Game = GamesDataset["games"][number];
-
-const gameMap: Record<string, Game> = gamesData.games.reduce(
-    (acc, game) => {
-        acc[game.id] = game;
-        return acc;
-    },
-    {} as Record<string, Game>,
-);
-
 interface GameCardsRowProps {
     gameIds?: string[];
 }
 
 export function GameCardsRow({ gameIds }: GameCardsRowProps) {
-    const gamesToRender: Game[] = gameIds?.length
-        ? gameIds.map((id) => gameMap[id]).filter((game): game is Game => Boolean(game))
-        : gamesData.games;
+    const [games, setGames] = useState<Game[]>(fallbackGames);
+
+    useEffect(() => {
+        apiClient
+            .getGames()
+            .then((res) => setGames(res.data))
+            .catch(() => {}); // keep fallback on error
+    }, []);
+
+    const gamesToRender = gameIds?.length
+        ? games.filter((g) => gameIds.includes(g.gameId))
+        : games;
 
     return (
         <Carousel>
             {gamesToRender.map((game) => (
                 <GameCard
-                    key={game.id}
-                    id={game.id}
-                    src={game.image}
+                    key={game.gameId}
+                    id={game.gameId}
+                    src={game.imageUrl}
                     alt={game.name}
                     title={game.name}
-                    modes={game.modes}
+                    modes={game.modes ?? []}
                     tags={game.tags}
                 />
             ))}

--- a/frontend/components/game-card/game-cards-row.tsx
+++ b/frontend/components/game-card/game-cards-row.tsx
@@ -47,9 +47,7 @@ export function GameCardsRow({ gameIds }: GameCardsRowProps) {
             .catch(() => {}); // keep fallback on error
     }, []);
 
-    const gamesToRender = gameIds?.length
-        ? games.filter((g) => gameIds.includes(g.gameId))
-        : games;
+    const gamesToRender = gameIds?.length ? games.filter((g) => gameIds.includes(g.gameId)) : games;
 
     return (
         <Carousel>

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1,3 +1,25 @@
+export interface Game {
+    gameId: string;
+    name: string;
+    description: string;
+    imageUrl: string;
+    tags: string[];
+    modes?: string[];
+    ebsSnapshotId: string;
+    minInstanceType: string;
+    playable?: boolean;
+}
+
+export interface GetGamesResponse {
+    message: string;
+    data: Game[];
+}
+
+export interface GetGameResponse {
+    message: string;
+    data: Game;
+}
+
 export interface DeployInstanceRequest {
     userId: string;
 }
@@ -248,6 +270,14 @@ class ApiClient {
         return this.request<GetCheckoutSessionResponse>(`/checkout-session?${params.toString()}`, {
             method: "GET",
         });
+    }
+
+    async getGames(): Promise<GetGamesResponse> {
+        return this.request<GetGamesResponse>("/games");
+    }
+
+    async getGame(gameId: string): Promise<GetGameResponse> {
+        return this.request<GetGameResponse>(`/games/${encodeURIComponent(gameId)}`);
     }
 }
 


### PR DESCRIPTION
## Summary

Frontend now fetches from games endpoints, but still falls back to static games. 

Replaced placeholders in browsing page with GameCard components. Split arbitrarily into "popular" and "featured" games. 

## How to test
Visually verify the frontend pages, including the home page, browse page, and specific game page. 
